### PR TITLE
1.19.2 quifabrge - Removed "cherry"

### DIFF
--- a/common/src/main/java/com/fizzware/dramaticdoors/DDNames.java
+++ b/common/src/main/java/com/fizzware/dramaticdoors/DDNames.java
@@ -12,7 +12,6 @@ public class DDNames
     public static final String SHORT_DARK_OAK = "short_dark_oak_door";
     public static final String SHORT_MANGROVE = "short_mangrove_door";
     public static final String SHORT_BAMBOO = "short_bamboo_door";
-    public static final String SHORT_CHERRY = "short_cherry_door";
     public static final String SHORT_CRIMSON = "short_crimson_door";
     public static final String SHORT_WARPED = "short_warped_door";
     
@@ -25,7 +24,6 @@ public class DDNames
     public static final String TALL_DARK_OAK = "tall_dark_oak_door";
     public static final String TALL_MANGROVE = "tall_mangrove_door";
     public static final String TALL_BAMBOO = "tall_bamboo_door";
-    public static final String TALL_CHERRY = "tall_cherry_door";
     public static final String TALL_CRIMSON = "tall_crimson_door";
     public static final String TALL_WARPED = "tall_warped_door";
 

--- a/common/src/main/java/com/fizzware/dramaticdoors/DDNames.java
+++ b/common/src/main/java/com/fizzware/dramaticdoors/DDNames.java
@@ -1372,7 +1372,6 @@ public class DDNames
     public static final String SHORT_MACAW_ACACIA_BARN = "short_macaw_acacia_barn_door";
     public static final String SHORT_MACAW_BAMBOO_BARN = "short_macaw_bamboo_barn_door";
     public static final String SHORT_MACAW_BIRCH_BARN = "short_macaw_birch_barn_door";
-    public static final String SHORT_MACAW_CHERRY_BARN = "short_macaw_cherry_barn_door";
     public static final String SHORT_MACAW_CRIMSON_BARN = "short_macaw_crimson_barn_door";
     public static final String SHORT_MACAW_DARK_OAK_BARN = "short_macaw_dark_oak_barn_door";
     public static final String SHORT_MACAW_JUNGLE_BARN = "short_macaw_jungle_barn_door";
@@ -1384,7 +1383,6 @@ public class DDNames
     public static final String SHORT_MACAW_ACACIA_BARN_GLASS = "short_macaw_acacia_barn_glass_door";
     public static final String SHORT_MACAW_BAMBOO_BARN_GLASS = "short_macaw_bamboo_barn_glass_door";
     public static final String SHORT_MACAW_BIRCH_BARN_GLASS = "short_macaw_birch_barn_glass_door";
-    public static final String SHORT_MACAW_CHERRY_BARN_GLASS = "short_macaw_cherry_barn_glass_door";
     public static final String SHORT_MACAW_CRIMSON_BARN_GLASS = "short_macaw_crimson_barn_glass_door";
     public static final String SHORT_MACAW_DARK_OAK_BARN_GLASS = "short_macaw_dark_oak_barn_glass_door";
     public static final String SHORT_MACAW_JUNGLE_BARN_GLASS = "short_macaw_jungle_barn_glass_door";
@@ -1396,7 +1394,6 @@ public class DDNames
     public static final String SHORT_MACAW_ACACIA_STABLE = "short_macaw_acacia_stable_door";
     public static final String SHORT_MACAW_BAMBOO_STABLE = "short_macaw_bamboo_stable_door";
     public static final String SHORT_MACAW_BIRCH_STABLE = "short_macaw_birch_stable_door";
-    public static final String SHORT_MACAW_CHERRY_STABLE = "short_macaw_cherry_stable_door";
     public static final String SHORT_MACAW_CRIMSON_STABLE = "short_macaw_crimson_stable_door";
     public static final String SHORT_MACAW_DARK_OAK_STABLE = "short_macaw_dark_oak_stable_door";
     public static final String SHORT_MACAW_JUNGLE_STABLE = "short_macaw_jungle_stable_door";
@@ -1408,7 +1405,6 @@ public class DDNames
     public static final String SHORT_MACAW_ACACIA_STABLE_HEAD = "short_macaw_acacia_stable_head_door";
     public static final String SHORT_MACAW_BAMBOO_STABLE_HEAD = "short_macaw_bamboo_stable_head_door";
     public static final String SHORT_MACAW_BIRCH_STABLE_HEAD = "short_macaw_birch_stable_head_door";
-    public static final String SHORT_MACAW_CHERRY_STABLE_HEAD = "short_macaw_cherry_stable_head_door";
     public static final String SHORT_MACAW_CRIMSON_STABLE_HEAD = "short_macaw_crimson_stable_head_door";
     public static final String SHORT_MACAW_DARK_OAK_STABLE_HEAD = "short_macaw_dark_oak_stable_head_door";
     public static final String SHORT_MACAW_JUNGLE_STABLE_HEAD = "short_macaw_jungle_stable_head_door";
@@ -1420,7 +1416,6 @@ public class DDNames
     public static final String SHORT_MACAW_ACACIA_GLASS = "short_macaw_acacia_glass_door";
     public static final String SHORT_MACAW_BAMBOO_GLASS = "short_macaw_bamboo_glass_door";
     public static final String SHORT_MACAW_BIRCH_GLASS = "short_macaw_birch_glass_door";
-    public static final String SHORT_MACAW_CHERRY_GLASS = "short_macaw_cherry_glass_door";
     public static final String SHORT_MACAW_CRIMSON_GLASS = "short_macaw_crimson_glass_door";
     public static final String SHORT_MACAW_DARK_OAK_GLASS = "short_macaw_dark_oak_glass_door";
     public static final String SHORT_MACAW_JUNGLE_GLASS = "short_macaw_jungle_glass_door";
@@ -1432,7 +1427,6 @@ public class DDNames
     public static final String SHORT_MACAW_ACACIA_BARK_GLASS = "short_macaw_acacia_bark_glass_door";
     public static final String SHORT_MACAW_BAMBOO_BARK_GLASS = "short_macaw_bamboo_bark_glass_door";
     public static final String SHORT_MACAW_BIRCH_BARK_GLASS = "short_macaw_birch_bark_glass_door";
-    public static final String SHORT_MACAW_CHERRY_BARK_GLASS = "short_macaw_cherry_bark_glass_door";
     public static final String SHORT_MACAW_CRIMSON_STEM_GLASS = "short_macaw_crimson_stem_glass_door";
     public static final String SHORT_MACAW_DARK_OAK_BARK_GLASS = "short_macaw_dark_oak_bark_glass_door";
     public static final String SHORT_MACAW_JUNGLE_BARK_GLASS = "short_macaw_jungle_bark_glass_door";
@@ -1444,7 +1438,6 @@ public class DDNames
     public static final String SHORT_MACAW_ACACIA_MODERN = "short_macaw_acacia_modern_door";
     public static final String SHORT_MACAW_BAMBOO_MODERN = "short_macaw_bamboo_modern_door";
     public static final String SHORT_MACAW_BIRCH_MODERN = "short_macaw_birch_modern_door";
-    public static final String SHORT_MACAW_CHERRY_MODERN = "short_macaw_cherry_modern_door";
     public static final String SHORT_MACAW_CRIMSON_MODERN = "short_macaw_crimson_modern_door";
     public static final String SHORT_MACAW_DARK_OAK_MODERN = "short_macaw_dark_oak_modern_door";
     public static final String SHORT_MACAW_JUNGLE_MODERN = "short_macaw_jungle_modern_door";
@@ -1456,7 +1449,6 @@ public class DDNames
     public static final String SHORT_MACAW_ACACIA_JAPANESE = "short_macaw_acacia_japanese_door";
     public static final String SHORT_MACAW_BAMBOO_JAPANESE = "short_macaw_bamboo_japanese_door";
     public static final String SHORT_MACAW_BIRCH_JAPANESE = "short_macaw_birch_japanese_door";
-    public static final String SHORT_MACAW_CHERRY_JAPANESE = "short_macaw_cherry_japanese_door";
     public static final String SHORT_MACAW_CRIMSON_JAPANESE = "short_macaw_crimson_japanese_door";
     public static final String SHORT_MACAW_DARK_OAK_JAPANESE = "short_macaw_dark_oak_japanese_door";
     public static final String SHORT_MACAW_JUNGLE_JAPANESE = "short_macaw_jungle_japanese_door";
@@ -1468,7 +1460,6 @@ public class DDNames
     public static final String SHORT_MACAW_ACACIA_JAPANESE2 = "short_macaw_acacia_japanese2_door";
     public static final String SHORT_MACAW_BAMBOO_JAPANESE2 = "short_macaw_bamboo_japanese2_door";
     public static final String SHORT_MACAW_BIRCH_JAPANESE2 = "short_macaw_birch_japanese2_door";
-    public static final String SHORT_MACAW_CHERRY_JAPANESE2 = "short_macaw_cherry_japanese2_door";
     public static final String SHORT_MACAW_CRIMSON_JAPANESE2 = "short_macaw_crimson_japanese2_door";
     public static final String SHORT_MACAW_DARK_OAK_JAPANESE2 = "short_macaw_dark_oak_japanese2_door";
     public static final String SHORT_MACAW_JUNGLE_JAPANESE2 = "short_macaw_jungle_japanese2_door";
@@ -1479,7 +1470,6 @@ public class DDNames
     
     public static final String SHORT_MACAW_ACACIA_BAMBOO = "short_macaw_acacia_bamboo_door";
     public static final String SHORT_MACAW_BIRCH_BAMBOO = "short_macaw_birch_bamboo_door";
-    public static final String SHORT_MACAW_CHERRY_BAMBOO = "short_macaw_cherry_bamboo_door";
     public static final String SHORT_MACAW_CRIMSON_BAMBOO = "short_macaw_crimson_bamboo_door";
     public static final String SHORT_MACAW_DARK_OAK_BAMBOO = "short_macaw_dark_oak_bamboo_door";
     public static final String SHORT_MACAW_JUNGLE_BAMBOO = "short_macaw_jungle_bamboo_door";
@@ -1491,7 +1481,6 @@ public class DDNames
     public static final String SHORT_MACAW_ACACIA_BEACH = "short_macaw_acacia_beach_door";
     public static final String SHORT_MACAW_BAMBOO_BEACH = "short_macaw_bamboo_beach_door";
     public static final String SHORT_MACAW_BIRCH_BEACH = "short_macaw_birch_beach_door";
-    public static final String SHORT_MACAW_CHERRY_BEACH = "short_macaw_cherry_beach_door";
     public static final String SHORT_MACAW_CRIMSON_BEACH = "short_macaw_crimson_beach_door";
     public static final String SHORT_MACAW_DARK_OAK_BEACH = "short_macaw_dark_oak_beach_door";
     public static final String SHORT_MACAW_JUNGLE_BEACH = "short_macaw_jungle_beach_door";
@@ -1503,7 +1492,6 @@ public class DDNames
     public static final String SHORT_MACAW_ACACIA_CLASSIC = "short_macaw_acacia_classic_door";
     public static final String SHORT_MACAW_BAMBOO_CLASSIC = "short_macaw_bamboo_classic_door";
     public static final String SHORT_MACAW_BIRCH_CLASSIC = "short_macaw_birch_classic_door";
-    public static final String SHORT_MACAW_CHERRY_CLASSIC = "short_macaw_cherry_classic_door";
     public static final String SHORT_MACAW_CRIMSON_CLASSIC = "short_macaw_crimson_classic_door";
     public static final String SHORT_MACAW_DARK_OAK_CLASSIC = "short_macaw_dark_oak_classic_door";
     public static final String SHORT_MACAW_JUNGLE_CLASSIC = "short_macaw_jungle_classic_door";
@@ -1515,7 +1503,6 @@ public class DDNames
     public static final String SHORT_MACAW_ACACIA_COTTAGE = "short_macaw_acacia_cottage_door";
     public static final String SHORT_MACAW_BAMBOO_COTTAGE = "short_macaw_bamboo_cottage_door";
     public static final String SHORT_MACAW_BIRCH_COTTAGE = "short_macaw_birch_cottage_door";
-    public static final String SHORT_MACAW_CHERRY_COTTAGE = "short_macaw_cherry_cottage_door";
     public static final String SHORT_MACAW_CRIMSON_COTTAGE = "short_macaw_crimson_cottage_door";
     public static final String SHORT_MACAW_DARK_OAK_COTTAGE = "short_macaw_dark_oak_cottage_door";
     public static final String SHORT_MACAW_JUNGLE_COTTAGE = "short_macaw_jungle_cottage_door";
@@ -1527,7 +1514,6 @@ public class DDNames
     public static final String SHORT_MACAW_ACACIA_FOUR_PANEL = "short_macaw_acacia_four_panel_door";
     public static final String SHORT_MACAW_BAMBOO_FOUR_PANEL = "short_macaw_bamboo_four_panel_door";
     public static final String SHORT_MACAW_BIRCH_FOUR_PANEL = "short_macaw_birch_four_panel_door";
-    public static final String SHORT_MACAW_CHERRY_FOUR_PANEL = "short_macaw_cherry_four_panel_door";
     public static final String SHORT_MACAW_CRIMSON_FOUR_PANEL = "short_macaw_crimson_four_panel_door";
     public static final String SHORT_MACAW_DARK_OAK_FOUR_PANEL = "short_macaw_dark_oak_four_panel_door";
     public static final String SHORT_MACAW_JUNGLE_FOUR_PANEL = "short_macaw_jungle_four_panel_door";
@@ -1539,7 +1525,6 @@ public class DDNames
     public static final String SHORT_MACAW_ACACIA_MYSTIC = "short_macaw_acacia_mystic_door";
     public static final String SHORT_MACAW_BAMBOO_MYSTIC = "short_macaw_bamboo_mystic_door";
     public static final String SHORT_MACAW_BIRCH_MYSTIC = "short_macaw_birch_mystic_door";
-    public static final String SHORT_MACAW_CHERRY_MYSTIC = "short_macaw_cherry_mystic_door";
     public static final String SHORT_MACAW_CRIMSON_MYSTIC = "short_macaw_crimson_mystic_door";
     public static final String SHORT_MACAW_DARK_OAK_MYSTIC = "short_macaw_dark_oak_mystic_door";
     public static final String SHORT_MACAW_JUNGLE_MYSTIC = "short_macaw_jungle_mystic_door";
@@ -1551,7 +1536,6 @@ public class DDNames
     public static final String SHORT_MACAW_ACACIA_NETHER = "short_macaw_acacia_nether_door";
     public static final String SHORT_MACAW_BAMBOO_NETHER = "short_macaw_bamboo_nether_door";
     public static final String SHORT_MACAW_BIRCH_NETHER = "short_macaw_birch_nether_door";
-    public static final String SHORT_MACAW_CHERRY_NETHER = "short_macaw_cherry_nether_door";
     public static final String SHORT_MACAW_CRIMSON_NETHER = "short_macaw_crimson_nether_door";
     public static final String SHORT_MACAW_DARK_OAK_NETHER = "short_macaw_dark_oak_nether_door";
     public static final String SHORT_MACAW_JUNGLE_NETHER = "short_macaw_jungle_nether_door";
@@ -1563,7 +1547,6 @@ public class DDNames
     public static final String SHORT_MACAW_ACACIA_PAPER = "short_macaw_acacia_paper_door";
     public static final String SHORT_MACAW_BAMBOO_PAPER = "short_macaw_bamboo_paper_door";
     public static final String SHORT_MACAW_BIRCH_PAPER = "short_macaw_birch_paper_door";
-    public static final String SHORT_MACAW_CHERRY_PAPER = "short_macaw_cherry_paper_door";
     public static final String SHORT_MACAW_CRIMSON_PAPER = "short_macaw_crimson_paper_door";
     public static final String SHORT_MACAW_DARK_OAK_PAPER = "short_macaw_dark_oak_paper_door";
     public static final String SHORT_MACAW_JUNGLE_PAPER = "short_macaw_jungle_paper_door";
@@ -1575,7 +1558,6 @@ public class DDNames
     public static final String SHORT_MACAW_ACACIA_SWAMP = "short_macaw_acacia_swamp_door";
     public static final String SHORT_MACAW_BAMBOO_SWAMP = "short_macaw_bamboo_swamp_door";
     public static final String SHORT_MACAW_BIRCH_SWAMP = "short_macaw_birch_swamp_door";
-    public static final String SHORT_MACAW_CHERRY_SWAMP = "short_macaw_cherry_swamp_door";
     public static final String SHORT_MACAW_CRIMSON_SWAMP = "short_macaw_crimson_swamp_door";
     public static final String SHORT_MACAW_DARK_OAK_SWAMP = "short_macaw_dark_oak_swamp_door";
     public static final String SHORT_MACAW_JUNGLE_SWAMP = "short_macaw_jungle_swamp_door";
@@ -1587,7 +1569,6 @@ public class DDNames
     public static final String SHORT_MACAW_ACACIA_TROPICAL = "short_macaw_acacia_tropical_door";
     public static final String SHORT_MACAW_BAMBOO_TROPICAL = "short_macaw_bamboo_tropical_door";
     public static final String SHORT_MACAW_BIRCH_TROPICAL = "short_macaw_birch_tropical_door";
-    public static final String SHORT_MACAW_CHERRY_TROPICAL = "short_macaw_cherry_tropical_door";
     public static final String SHORT_MACAW_CRIMSON_TROPICAL = "short_macaw_crimson_tropical_door";
     public static final String SHORT_MACAW_DARK_OAK_TROPICAL = "short_macaw_dark_oak_tropical_door";
     public static final String SHORT_MACAW_JUNGLE_TROPICAL = "short_macaw_jungle_tropical_door";
@@ -1599,7 +1580,6 @@ public class DDNames
     public static final String SHORT_MACAW_ACACIA_WAFFLE = "short_macaw_acacia_waffle_door";
     public static final String SHORT_MACAW_BAMBOO_WAFFLE = "short_macaw_bamboo_waffle_door";
     public static final String SHORT_MACAW_BIRCH_WAFFLE = "short_macaw_birch_waffle_door";
-    public static final String SHORT_MACAW_CHERRY_WAFFLE = "short_macaw_cherry_waffle_door";
     public static final String SHORT_MACAW_CRIMSON_WAFFLE = "short_macaw_crimson_waffle_door";
     public static final String SHORT_MACAW_DARK_OAK_WAFFLE = "short_macaw_dark_oak_waffle_door";
     public static final String SHORT_MACAW_JUNGLE_WAFFLE = "short_macaw_jungle_waffle_door";
@@ -1621,7 +1601,7 @@ public class DDNames
     public static final String TALL_MACAW_ACACIA_BARN = "tall_macaw_acacia_barn_door";
     public static final String TALL_MACAW_BAMBOO_BARN = "tall_macaw_bamboo_barn_door";
     public static final String TALL_MACAW_BIRCH_BARN = "tall_macaw_birch_barn_door";
-    public static final String TALL_MACAW_CHERRY_BARN = "tall_macaw_cherry_barn_door";
+
     public static final String TALL_MACAW_CRIMSON_BARN = "tall_macaw_crimson_barn_door";
     public static final String TALL_MACAW_DARK_OAK_BARN = "tall_macaw_dark_oak_barn_door";
     public static final String TALL_MACAW_JUNGLE_BARN = "tall_macaw_jungle_barn_door";
@@ -1633,7 +1613,7 @@ public class DDNames
     public static final String TALL_MACAW_ACACIA_BARN_GLASS = "tall_macaw_acacia_barn_glass_door";
     public static final String TALL_MACAW_BAMBOO_BARN_GLASS = "tall_macaw_bamboo_barn_glass_door";
     public static final String TALL_MACAW_BIRCH_BARN_GLASS = "tall_macaw_birch_barn_glass_door";
-    public static final String TALL_MACAW_CHERRY_BARN_GLASS = "tall_macaw_cherry_barn_glass_door";
+
     public static final String TALL_MACAW_CRIMSON_BARN_GLASS = "tall_macaw_crimson_barn_glass_door";
     public static final String TALL_MACAW_DARK_OAK_BARN_GLASS = "tall_macaw_dark_oak_barn_glass_door";
     public static final String TALL_MACAW_JUNGLE_BARN_GLASS = "tall_macaw_jungle_barn_glass_door";
@@ -1645,7 +1625,7 @@ public class DDNames
     public static final String TALL_MACAW_ACACIA_STABLE = "tall_macaw_acacia_stable_door";
     public static final String TALL_MACAW_BAMBOO_STABLE = "tall_macaw_bamboo_stable_door";
     public static final String TALL_MACAW_BIRCH_STABLE = "tall_macaw_birch_stable_door";
-    public static final String TALL_MACAW_CHERRY_STABLE = "tall_macaw_cherry_stable_door";
+
     public static final String TALL_MACAW_CRIMSON_STABLE = "tall_macaw_crimson_stable_door";
     public static final String TALL_MACAW_DARK_OAK_STABLE = "tall_macaw_dark_oak_stable_door";
     public static final String TALL_MACAW_JUNGLE_STABLE = "tall_macaw_jungle_stable_door";
@@ -1657,7 +1637,6 @@ public class DDNames
     public static final String TALL_MACAW_ACACIA_STABLE_HEAD = "tall_macaw_acacia_stable_head_door";
     public static final String TALL_MACAW_BAMBOO_STABLE_HEAD = "tall_macaw_bamboo_stable_head_door";
     public static final String TALL_MACAW_BIRCH_STABLE_HEAD = "tall_macaw_birch_stable_head_door";
-    public static final String TALL_MACAW_CHERRY_STABLE_HEAD = "tall_macaw_cherry_stable_head_door";
     public static final String TALL_MACAW_CRIMSON_STABLE_HEAD = "tall_macaw_crimson_stable_head_door";
     public static final String TALL_MACAW_DARK_OAK_STABLE_HEAD = "tall_macaw_dark_oak_stable_head_door";
     public static final String TALL_MACAW_JUNGLE_STABLE_HEAD = "tall_macaw_jungle_stable_head_door";
@@ -1669,7 +1648,6 @@ public class DDNames
     public static final String TALL_MACAW_ACACIA_GLASS = "tall_macaw_acacia_glass_door";
     public static final String TALL_MACAW_BAMBOO_GLASS = "tall_macaw_bamboo_glass_door";
     public static final String TALL_MACAW_BIRCH_GLASS = "tall_macaw_birch_glass_door";
-    public static final String TALL_MACAW_CHERRY_GLASS = "tall_macaw_cherry_glass_door";
     public static final String TALL_MACAW_CRIMSON_GLASS = "tall_macaw_crimson_glass_door";
     public static final String TALL_MACAW_DARK_OAK_GLASS = "tall_macaw_dark_oak_glass_door";
     public static final String TALL_MACAW_JUNGLE_GLASS = "tall_macaw_jungle_glass_door";
@@ -1681,7 +1659,6 @@ public class DDNames
     public static final String TALL_MACAW_ACACIA_BARK_GLASS = "tall_macaw_acacia_bark_glass_door";
     public static final String TALL_MACAW_BAMBOO_BARK_GLASS = "tall_macaw_bamboo_bark_glass_door";
     public static final String TALL_MACAW_BIRCH_BARK_GLASS = "tall_macaw_birch_bark_glass_door";
-    public static final String TALL_MACAW_CHERRY_BARK_GLASS = "tall_macaw_cherry_bark_glass_door";
     public static final String TALL_MACAW_CRIMSON_STEM_GLASS = "tall_macaw_crimson_stem_glass_door";
     public static final String TALL_MACAW_DARK_OAK_BARK_GLASS = "tall_macaw_dark_oak_bark_glass_door";
     public static final String TALL_MACAW_JUNGLE_BARK_GLASS = "tall_macaw_jungle_bark_glass_door";
@@ -1693,7 +1670,6 @@ public class DDNames
     public static final String TALL_MACAW_ACACIA_MODERN = "tall_macaw_acacia_modern_door";
     public static final String TALL_MACAW_BAMBOO_MODERN = "tall_macaw_bamboo_modern_door";
     public static final String TALL_MACAW_BIRCH_MODERN = "tall_macaw_birch_modern_door";
-    public static final String TALL_MACAW_CHERRY_MODERN = "tall_macaw_cherry_modern_door";
     public static final String TALL_MACAW_CRIMSON_MODERN = "tall_macaw_crimson_modern_door";
     public static final String TALL_MACAW_DARK_OAK_MODERN = "tall_macaw_dark_oak_modern_door";
     public static final String TALL_MACAW_JUNGLE_MODERN = "tall_macaw_jungle_modern_door";
@@ -1705,7 +1681,6 @@ public class DDNames
     public static final String TALL_MACAW_ACACIA_JAPANESE = "tall_macaw_acacia_japanese_door";
     public static final String TALL_MACAW_BAMBOO_JAPANESE = "tall_macaw_bamboo_japanese_door";
     public static final String TALL_MACAW_BIRCH_JAPANESE = "tall_macaw_birch_japanese_door";
-    public static final String TALL_MACAW_CHERRY_JAPANESE = "tall_macaw_cherry_japanese_door";
     public static final String TALL_MACAW_CRIMSON_JAPANESE = "tall_macaw_crimson_japanese_door";
     public static final String TALL_MACAW_DARK_OAK_JAPANESE = "tall_macaw_dark_oak_japanese_door";
     public static final String TALL_MACAW_JUNGLE_JAPANESE = "tall_macaw_jungle_japanese_door";
@@ -1717,7 +1692,6 @@ public class DDNames
     public static final String TALL_MACAW_ACACIA_JAPANESE2 = "tall_macaw_acacia_japanese2_door";
     public static final String TALL_MACAW_BAMBOO_JAPANESE2 = "tall_macaw_bamboo_japanese2_door";
     public static final String TALL_MACAW_BIRCH_JAPANESE2 = "tall_macaw_birch_japanese2_door";
-    public static final String TALL_MACAW_CHERRY_JAPANESE2 = "tall_macaw_cherry_japanese2_door";
     public static final String TALL_MACAW_CRIMSON_JAPANESE2 = "tall_macaw_crimson_japanese2_door";
     public static final String TALL_MACAW_DARK_OAK_JAPANESE2 = "tall_macaw_dark_oak_japanese2_door";
     public static final String TALL_MACAW_JUNGLE_JAPANESE2 = "tall_macaw_jungle_japanese2_door";
@@ -1728,7 +1702,6 @@ public class DDNames
     
     public static final String TALL_MACAW_ACACIA_BAMBOO = "tall_macaw_acacia_bamboo_door";
     public static final String TALL_MACAW_BIRCH_BAMBOO = "tall_macaw_birch_bamboo_door";
-    public static final String TALL_MACAW_CHERRY_BAMBOO = "tall_macaw_cherry_bamboo_door";
     public static final String TALL_MACAW_CRIMSON_BAMBOO = "tall_macaw_crimson_bamboo_door";
     public static final String TALL_MACAW_DARK_OAK_BAMBOO = "tall_macaw_dark_oak_bamboo_door";
     public static final String TALL_MACAW_JUNGLE_BAMBOO = "tall_macaw_jungle_bamboo_door";
@@ -1740,7 +1713,6 @@ public class DDNames
     public static final String TALL_MACAW_ACACIA_BEACH = "tall_macaw_acacia_beach_door";
     public static final String TALL_MACAW_BAMBOO_BEACH = "tall_macaw_bamboo_beach_door";
     public static final String TALL_MACAW_BIRCH_BEACH = "tall_macaw_birch_beach_door";
-    public static final String TALL_MACAW_CHERRY_BEACH = "tall_macaw_cherry_beach_door";
     public static final String TALL_MACAW_CRIMSON_BEACH = "tall_macaw_crimson_beach_door";
     public static final String TALL_MACAW_DARK_OAK_BEACH = "tall_macaw_dark_oak_beach_door";
     public static final String TALL_MACAW_JUNGLE_BEACH = "tall_macaw_jungle_beach_door";
@@ -1752,7 +1724,6 @@ public class DDNames
     public static final String TALL_MACAW_ACACIA_CLASSIC = "tall_macaw_acacia_classic_door";
     public static final String TALL_MACAW_BAMBOO_CLASSIC = "tall_macaw_bamboo_classic_door";
     public static final String TALL_MACAW_BIRCH_CLASSIC = "tall_macaw_birch_classic_door";
-    public static final String TALL_MACAW_CHERRY_CLASSIC = "tall_macaw_cherry_classic_door";
     public static final String TALL_MACAW_CRIMSON_CLASSIC = "tall_macaw_crimson_classic_door";
     public static final String TALL_MACAW_DARK_OAK_CLASSIC = "tall_macaw_dark_oak_classic_door";
     public static final String TALL_MACAW_JUNGLE_CLASSIC = "tall_macaw_jungle_classic_door";
@@ -1764,7 +1735,6 @@ public class DDNames
     public static final String TALL_MACAW_ACACIA_COTTAGE = "tall_macaw_acacia_cottage_door";
     public static final String TALL_MACAW_BAMBOO_COTTAGE = "tall_macaw_bamboo_cottage_door";
     public static final String TALL_MACAW_BIRCH_COTTAGE = "tall_macaw_birch_cottage_door";
-    public static final String TALL_MACAW_CHERRY_COTTAGE = "tall_macaw_cherry_cottage_door";
     public static final String TALL_MACAW_CRIMSON_COTTAGE = "tall_macaw_crimson_cottage_door";
     public static final String TALL_MACAW_DARK_OAK_COTTAGE = "tall_macaw_dark_oak_cottage_door";
     public static final String TALL_MACAW_JUNGLE_COTTAGE = "tall_macaw_jungle_cottage_door";
@@ -1776,7 +1746,6 @@ public class DDNames
     public static final String TALL_MACAW_ACACIA_FOUR_PANEL = "tall_macaw_acacia_four_panel_door";
     public static final String TALL_MACAW_BAMBOO_FOUR_PANEL = "tall_macaw_bamboo_four_panel_door";
     public static final String TALL_MACAW_BIRCH_FOUR_PANEL = "tall_macaw_birch_four_panel_door";
-    public static final String TALL_MACAW_CHERRY_FOUR_PANEL = "tall_macaw_cherry_four_panel_door";
     public static final String TALL_MACAW_CRIMSON_FOUR_PANEL = "tall_macaw_crimson_four_panel_door";
     public static final String TALL_MACAW_DARK_OAK_FOUR_PANEL = "tall_macaw_dark_oak_four_panel_door";
     public static final String TALL_MACAW_JUNGLE_FOUR_PANEL = "tall_macaw_jungle_four_panel_door";
@@ -1788,7 +1757,6 @@ public class DDNames
     public static final String TALL_MACAW_ACACIA_MYSTIC = "tall_macaw_acacia_mystic_door";
     public static final String TALL_MACAW_BAMBOO_MYSTIC = "tall_macaw_bamboo_mystic_door";
     public static final String TALL_MACAW_BIRCH_MYSTIC = "tall_macaw_birch_mystic_door";
-    public static final String TALL_MACAW_CHERRY_MYSTIC = "tall_macaw_cherry_mystic_door";
     public static final String TALL_MACAW_CRIMSON_MYSTIC = "tall_macaw_crimson_mystic_door";
     public static final String TALL_MACAW_DARK_OAK_MYSTIC = "tall_macaw_dark_oak_mystic_door";
     public static final String TALL_MACAW_JUNGLE_MYSTIC = "tall_macaw_jungle_mystic_door";
@@ -1800,7 +1768,6 @@ public class DDNames
     public static final String TALL_MACAW_ACACIA_NETHER = "tall_macaw_acacia_nether_door";
     public static final String TALL_MACAW_BAMBOO_NETHER = "tall_macaw_bamboo_nether_door";
     public static final String TALL_MACAW_BIRCH_NETHER = "tall_macaw_birch_nether_door";
-    public static final String TALL_MACAW_CHERRY_NETHER = "tall_macaw_cherry_nether_door";
     public static final String TALL_MACAW_CRIMSON_NETHER = "tall_macaw_crimson_nether_door";
     public static final String TALL_MACAW_DARK_OAK_NETHER = "tall_macaw_dark_oak_nether_door";
     public static final String TALL_MACAW_JUNGLE_NETHER = "tall_macaw_jungle_nether_door";
@@ -1812,7 +1779,6 @@ public class DDNames
     public static final String TALL_MACAW_ACACIA_PAPER = "tall_macaw_acacia_paper_door";
     public static final String TALL_MACAW_BAMBOO_PAPER = "tall_macaw_bamboo_paper_door";
     public static final String TALL_MACAW_BIRCH_PAPER = "tall_macaw_birch_paper_door";
-    public static final String TALL_MACAW_CHERRY_PAPER = "tall_macaw_cherry_paper_door";
     public static final String TALL_MACAW_CRIMSON_PAPER = "tall_macaw_crimson_paper_door";
     public static final String TALL_MACAW_DARK_OAK_PAPER = "tall_macaw_dark_oak_paper_door";
     public static final String TALL_MACAW_JUNGLE_PAPER = "tall_macaw_jungle_paper_door";
@@ -1824,7 +1790,6 @@ public class DDNames
     public static final String TALL_MACAW_ACACIA_SWAMP = "tall_macaw_acacia_swamp_door";
     public static final String TALL_MACAW_BAMBOO_SWAMP = "tall_macaw_bamboo_swamp_door";
     public static final String TALL_MACAW_BIRCH_SWAMP = "tall_macaw_birch_swamp_door";
-    public static final String TALL_MACAW_CHERRY_SWAMP = "tall_macaw_cherry_swamp_door";
     public static final String TALL_MACAW_CRIMSON_SWAMP = "tall_macaw_crimson_swamp_door";
     public static final String TALL_MACAW_DARK_OAK_SWAMP = "tall_macaw_dark_oak_swamp_door";
     public static final String TALL_MACAW_JUNGLE_SWAMP = "tall_macaw_jungle_swamp_door";
@@ -1836,7 +1801,6 @@ public class DDNames
     public static final String TALL_MACAW_ACACIA_TROPICAL = "tall_macaw_acacia_tropical_door";
     public static final String TALL_MACAW_BAMBOO_TROPICAL = "tall_macaw_bamboo_tropical_door";
     public static final String TALL_MACAW_BIRCH_TROPICAL = "tall_macaw_birch_tropical_door";
-    public static final String TALL_MACAW_CHERRY_TROPICAL = "tall_macaw_cherry_tropical_door";
     public static final String TALL_MACAW_CRIMSON_TROPICAL = "tall_macaw_crimson_tropical_door";
     public static final String TALL_MACAW_DARK_OAK_TROPICAL = "tall_macaw_dark_oak_tropical_door";
     public static final String TALL_MACAW_JUNGLE_TROPICAL = "tall_macaw_jungle_tropical_door";
@@ -1848,7 +1812,6 @@ public class DDNames
     public static final String TALL_MACAW_ACACIA_WAFFLE = "tall_macaw_acacia_waffle_door";
     public static final String TALL_MACAW_BAMBOO_WAFFLE = "tall_macaw_bamboo_waffle_door";
     public static final String TALL_MACAW_BIRCH_WAFFLE = "tall_macaw_birch_waffle_door";
-    public static final String TALL_MACAW_CHERRY_WAFFLE = "tall_macaw_cherry_waffle_door";
     public static final String TALL_MACAW_CRIMSON_WAFFLE = "tall_macaw_crimson_waffle_door";
     public static final String TALL_MACAW_DARK_OAK_WAFFLE = "tall_macaw_dark_oak_waffle_door";
     public static final String TALL_MACAW_JUNGLE_WAFFLE = "tall_macaw_jungle_waffle_door";

--- a/common/src/main/java/com/fizzware/dramaticdoors/DDNames.java
+++ b/common/src/main/java/com/fizzware/dramaticdoors/DDNames.java
@@ -1000,7 +1000,7 @@ public class DDNames
     public static final String SHORT_RUE_BAOBAB = "short_rue_baobab_door";
     public static final String SHORT_RUE_BLACKWOOD = "short_rue_blackwood_door";
     public static final String SHORT_RUE_BRIMWOOD = "short_rue_brimwood_door";
-    public static final String SHORT_RUE_CHERRY = "short_rue_cherry_door";
+    // public static final String SHORT_RUE_CHERRY = "short_rue_cherry_door";
     public static final String SHORT_RUE_CYPRESS = "short_rue_cypress_door";
     public static final String SHORT_RUE_DEAD = "short_rue_dead_door";
     public static final String SHORT_RUE_EUCALYPTUS = "short_rue_eucalyptus_door";
@@ -1016,7 +1016,7 @@ public class DDNames
     public static final String TALL_RUE_BAOBAB = "tall_rue_baobab_door";
     public static final String TALL_RUE_BLACKWOOD = "tall_rue_blackwood_door";
     public static final String TALL_RUE_BRIMWOOD = "tall_rue_brimwood_door";
-    public static final String TALL_RUE_CHERRY = "tall_rue_cherry_door";
+    // public static final String TALL_RUE_CHERRY = "tall_rue_cherry_door";
     public static final String TALL_RUE_CYPRESS = "tall_rue_cypress_door";
     public static final String TALL_RUE_DEAD = "tall_rue_dead_door";
     public static final String TALL_RUE_EUCALYPTUS = "tall_rue_eucalyptus_door";


### PR DESCRIPTION
### Under: 
- Vanilla - see _Reasons_ below
- Macaw's Doors - don't have _cherry_ variants
- Regions Unexplored - don't have the _cherry_ door

#### Reason: 
Cherry doesn't exist in **1.19.2**, only in **1.20.1**

